### PR TITLE
feat(dock): replace Gantt chart configurations with puzzle editor and…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 English | [中文文档](README.zh-CN.md)
 
-[![npm (scoped)](https://img.shields.io/npm/v/%40zhongmiao/ngx-puzzle?style=flat)](https://www.npmjs.com/package/@zhongmiao/ngx-puzzle)
+[![npm version](https://img.shields.io/badge/ngx--puzzle-18.1.1-blue?style=flat)](https://www.npmjs.com/package/@zhongmiao/ngx-puzzle)
 [![npm](https://img.shields.io/npm/dm/%40zhongmiao/ngx-puzzle)](https://www.npmjs.com/package/@zhongmiao/ngx-puzzle)
 ![](https://img.shields.io/badge/Made%20with%20Angular-red?logo=angular)
-[![GitHub release date](https://img.shields.io/github/release-date/ark65/ngx-puzzle.svg?style=flat-square)](https://github.com/ark65/ngx-puzzle)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](LICENSE)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,10 +2,9 @@
 
 中文 | [English](README.md)
 
-[![npm (scoped)](https://img.shields.io/npm/v/%40zhongmiao/ngx-puzzle?style=flat)](https://www.npmjs.com/package/@zhongmiao/ngx-puzzle)
+[![npm version](https://img.shields.io/badge/ngx--puzzle-18.1.1-blue?style=flat)](https://www.npmjs.com/package/@zhongmiao/ngx-puzzle)
 [![npm](https://img.shields.io/npm/dm/%40zhongmiao/ngx-puzzle)](https://www.npmjs.com/package/@zhongmiao/ngx-puzzle)
 ![](https://img.shields.io/badge/Angular-%E7%94%A8%E4%BA%8E%E6%89%93%E9%80%A0-red?logo=angular)
-[![GitHub release date](https://img.shields.io/github/release-date/ark65/ngx-puzzle.svg?style=flat-square)](https://github.com/ark65/ngx-puzzle)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](LICENSE)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 

--- a/example/src/app/configuration/parameters/api/en-us.js
+++ b/example/src/app/configuration/parameters/api/en-us.js
@@ -1,379 +1,194 @@
 module.exports = [
-    {
-        type: 'component',
-        name: 'ngx-gantt',
-        description: '',
-        properties: [
-            {
-                name: 'items',
-                description: `Set data items. If you set items separately, they will be displayed in a list. If you need to display them in groups, you need to set the property groupId to correspond to the grouped data`,
-                type: 'GanttItem[]'
-            },
-            {
-                name: 'groups',
-                description: `Set grouped data`,
-                type: 'GanttGroup[]'
-            },
-            {
-                name: 'baselineItems',
-                description: `Set baseline comparison data`,
-                type: 'GanttBaselineItem[]'
-            },
-            {
-                name: 'viewType',
-                description: `Set view type`,
-                type: `day | month | quarter`,
-                default: 'month'
-            },
-            {
-                name: 'start',
-                description: `Set the start time of the Gantt chart in the format of a 10-digit timestamp`,
-                type: 'number'
-            },
-            {
-                name: 'end',
-                description: `Set the end time of the Gantt chart in the format of a 10-digit timestamp`,
-                type: 'number'
-            },
-            {
-                name: 'draggable',
-                description: `Set whether it can be dragged`,
-                type: 'boolean',
-                default: 'false'
-            },
-            {
-                name: 'virtualScrollEnabled',
-                description: `Set whether to use the virtual scrolling function`,
-                type: 'boolean',
-                default: 'true'
-            },
-            {
-                name: 'linkable',
-                description: `Set whether the association relationship can be connected`,
-                type: 'boolean',
-                default: 'false'
-            },
-
-            {
-                name: 'loading',
-                description: `Whether to display the loader`,
-                type: 'boolean',
-                default: 'false'
-            },
-
-            {
-                name: 'loadingDelay',
-                description: 'Set the number of `milliseconds` to ignore the loader display',
-                type: 'number',
-                default: '0'
-            },
-
-            {
-                name: 'maxLevel',
-                description: `Set the maximum display level`,
-                type: 'number',
-                default: 2
-            },
-
-            {
-                name: 'async',
-                description: `Set whether to start asynchronous`,
-                type: 'boolean',
-                default: 'false'
-            },
-            {
-                name: 'childrenResolve',
-                description: `Set the asynchronous data source return function, the return value is Observable data stream`,
-                type: 'Function'
-            },
-
-            {
-                name: 'styles',
-                description: `Configure built-in style options`,
-                type: 'GanttStyles'
-            },
-            {
-                name: 'viewOptions',
-                description: `Configure view options`,
-                type: 'GanttViewOptions'
-            },
-            {
-                name: 'disabledLoadOnScroll',
-                description: `Set whether to disable scroll loading`,
-                type: 'boolean',
-                default: false
-            },
-            {
-                name: 'selectable',
-                description: `Set whether to enable selection of the entire row`,
-                type: 'boolean',
-                default: 'false'
-            },
-            {
-                name: 'multiple',
-                description: `Set whether to select the entire row in multiple selection mode`,
-                type: 'boolean',
-                default: 'false'
-            },
-            {
-                name: 'showToolbar',
-                description: `Set whether to display the toolbar`,
-                type: 'boolean',
-                default: 'false'
-            },
-            {
-                name: 'toolbarOptions',
-                description: `Toolbar configuration items`,
-                type: 'GanttToolbarOptions',
-                default: `{
-                viewTypes: [GanttViewType.day, GanttViewType.month, GanttViewType.year]
-                }`
-            },
-            {
-                name: 'loadOnScroll',
-                description: `Scroll loading event`,
-                type: 'EventEmitter<GanttLoadOnScrollEvent>'
-            },
-            {
-                name: 'dragStarted',
-                description: `Drag start event`,
-                type: 'EventEmitter<GanttDragEvent>'
-            },
-            {
-                name: 'dragEnded',
-                description: `Event after drag ends`,
-                type: 'EventEmitter<GanttDragEvent>'
-            },
-            {
-                name: 'linkDragStarted',
-                description: `Event after the relationship drag starts`,
-                type: 'EventEmitter<GanttLinkDragEvent>'
-            },
-            {
-                name: 'linkDragEnded',
-                description: `Event after the relationship drag ends`,
-                type: 'EventEmitter<GanttLinkDragEvent>'
-            },
-            {
-                name: 'barClick',
-                description: `Right time bar click event`,
-                type: 'EventEmitter<GanttBarClickEvent>'
-            },
-            {
-                name: 'lineClick',
-                description: `Relationship line click time`,
-                type: 'EventEmitter<GanttLinkDragEvent>'
-            },
-            {
-                name: 'selectedChange',
-                description: `Select data item event`,
-                type: 'EventEmitter<GanttSelectedEvent>'
-            },
-            {
-                name: 'virtualScrolledIndexChange',
-                description: `The index of the first element visible in the virtual scroll viewport has changed`,
-                type: 'EventEmitter<GanttVirtualScrolledIndexChangeEvent>'
-            },
-            {
-                name: '#group',
-                description: `Set group display template`,
-                type: 'TemplateRef<any>'
-            },
-            {
-                name: '#bar',
-                description: `Set time bar display template`,
-                type: 'TemplateRef<any>'
-            },
-            {
-                name: '#groupHeader',
-                description: `Set group header display template`,
-                type: 'TemplateRef<any>'
-            },
-            {
-                name: '#toolbar',
-                description: `Toolbar custom template`,
-                type: 'TemplateRef<any>'
-            },
-            {
-                name: '#tableFooter',
-                description: `Set the bottom template`,
-                type: 'TemplateRef<any>'
-            }
-        ]
-    },
-    {
-        type: 'component',
-        name: 'ngx-gantt-table',
-        description: 'Gantt chart left table',
-        properties: [
-            {
-                name: 'draggable',
-                description: `Set whether the table data items support dragging up and down sorting`,
-                default: false,
-                type: 'boolean'
-            },
-            {
-                name: 'dropEnterPredicate',
-                description: `This function is used to determine whether a data item is allowed to be dragged to other items`,
-                type: '(context: GanttTableDragEnterPredicateContext<T>) => boolean'
-            },
-            {
-                name: 'dragDropped',
-                description: `When a data item is dragged to another data item, it will be triggered`,
-                type: 'EventEmitter<GanttTableDragDroppedEvent>'
-            },
-            {
-                name: 'dragStarted',
-                description: `Drag starts after the event`,
-                type: 'EventEmitter<GanttTableDragStartedEvent>'
-            },
-            {
-                name: 'dragEnded',
-                description: `Drag ends after the event`,
-                type: 'EventEmitter<GanttTableDragEndedEvent>'
-            },
-            {
-                name: 'columnChanges',
-                description: `Column width change event set`,
-                type: 'EventEmitter<GanttTableEvent>'
-            },
-            {
-                name: 'itemClick',
-                description: `Select the entire row of data items event`,
-                type: 'EventEmitter<GanttSelectedEvent>'
-            },
-            {
-                name: '#rowBeforeSlot',
-                description: `Set the front custom rendering template for each row in the table`,
-                type: 'TemplateRef<any>'
-            },
-            {
-                name: '#rowAfterSlot',
-                description: `Set the back custom rendering template for each row in the table`,
-                type: 'TemplateRef<any>'
-            },
-            {
-                name: '#tableEmpty',
-                description: `Set the empty table template`,
-                type: 'TemplateRef<any>'
-            },
-            {
-                name: '#tableFooter',
-                description: `Set the table bottom template`,
-                type: 'TemplateRef<any>'
-            }
-        ]
-    },
-    {
-        type: 'component',
-        name: 'ngx-gantt-column',
-        description: 'Gantt chart left column',
-        properties: [
-            {
-                name: 'name',
-                description: `Set column name`,
-                type: 'string'
-            },
-            {
-                name: 'width',
-                description: `Set column width`,
-                type: 'string ｜ number'
-            },
-            {
-                name: '#header',
-                description: `Set each column header template`,
-                type: 'TemplateRef<any>'
-            },
-            {
-                name: '#cell',
-                description: `Set each column content template`,
-                type: 'TemplateRef<any>'
-            }
-        ]
-    },
-    {
-        type: 'component',
-        name: 'ngx-gantt-bar',
-        description: 'Data item bar chart display component',
-        properties: [
-            {
-                name: 'template',
-                description: `Set time bar display template`,
-                type: 'TemplateRef<any>'
-            },
-            {
-                name: 'item',
-                description: `Set time bar display data`,
-                type: 'GanttItemInternal'
-            },
-            {
-                name: 'barClick',
-                description: `Data item bar chart click event`,
-                type: 'EventEmitter<GanttBarClickEvent>'
-            }
-        ]
-    },
-    {
-        type: 'component',
-        name: 'ngx-gantt-range',
-        description: 'Data item range display component',
-        properties: [
-            {
-                name: 'template',
-                description: `Set range display template`,
-                type: 'TemplateRef<any>'
-            },
-            {
-                name: 'item',
-                description: `Set range display data`,
-                type: 'GanttItemInternal'
-            }
-        ]
-    },
-    {
-        type: 'component',
-        name: 'ngx-gantt-toolbar',
-        description: 'Toolbar component',
-        properties: [
-            {
-                name: 'template',
-                description: `Custom toolbar template`,
-                type: 'TemplateRef<any>'
-            }
-        ]
-    },
-    {
-        type: 'component',
-        name: 'ngx-gantt-baseline',
-        description: 'Baseline display component',
-        properties: [
-            {
-                name: 'baselineItem',
-                description: `Set baseline display data`,
-                type: 'GanttBaselineItemInternal'
-            }
-        ]
-    },
-    {
-        type: 'component',
-        name: 'ngx-gantt-root',
-        description: 'Gantt chart root component',
-        properties: [
-            {
-                name: 'sideWidth',
-                description: `Set the width of the left content of the Gantt chart`,
-                type: 'number'
-            },
-            {
-                name: 'sideTemplate',
-                description: `Set the content template on the left side of the Gantt chart`,
-                type: 'TemplateRef<any>'
-            },
-            {
-                name: 'mainTemplate',
-                description: `Set the main content template on the right side of the Gantt chart`,
-                type: 'TemplateRef<any>'
-            }
-        ]
-    }
+  {
+    type: 'component',
+    name: 'ngx-puzzle-editor',
+    description: 'Visual puzzle editor component (editor container)',
+    properties: [
+      {
+        name: 'selector',
+        description: 'Selector aliases',
+        type: "'ngx-puzzle-editor' | 'puzzle-editor'"
+      },
+      {
+        name: 'inputs',
+        description: 'No public inputs in this version. Internal state uses signals (leftCollapsed/rightCollapsed).',
+        type: '—'
+      },
+      {
+        name: 'outputs',
+        description: 'No public outputs in this version.',
+        type: '—'
+      }
+    ]
+  },
+  {
+    type: 'component',
+    name: 'ngx-puzzle-preview',
+    description: 'Puzzle preview component (renders canvas and components)',
+    properties: [
+      {
+        name: 'selector',
+        description: 'Selector aliases',
+        type: "'ngx-puzzle-preview' | 'puzzle-preview'"
+      },
+      {
+        name: 'enableZoom',
+        description: 'Enable zooming (two-way). true: scale to fit window width; false: show at original size.',
+        type: 'boolean',
+        default: true
+      },
+      {
+        name: 'enableZoomBtn',
+        description: 'Whether the zoom button is enabled; disabled when false.',
+        type: 'boolean',
+        default: false
+      },
+      {
+        name: 'enableFullscreenBtn',
+        description: 'Whether the fullscreen button is enabled.',
+        type: 'boolean',
+        default: true
+      },
+      {
+        name: 'previewId',
+        description: 'Preview ID (used only when previewMode is edit) to load temporary configs from session storage.',
+        type: 'string | undefined'
+      },
+      {
+        name: 'previewMode',
+        description: 'Preview mode: normal (uses only passedConfig) | edit (loads temporary data from session by previewId).',
+        type: "'normal' | 'edit'",
+        default: 'normal'
+      },
+      {
+        name: 'passedConfig',
+        description: 'Component configs for normal preview mode.',
+        type: 'ComponentConfig[] | undefined'
+      },
+      {
+        name: 'methods.toggleZoomMode()',
+        description: 'Toggle zoom mode; when turning off zoom, reset scale to 1.',
+        type: '() => void'
+      },
+      {
+        name: 'methods.isFullscreen()',
+        description: 'Whether it is currently in fullscreen.',
+        type: '() => boolean'
+      },
+      {
+        name: 'methods.toggleFullscreen()',
+        description: 'Toggle between fullscreen and normal.',
+        type: '() => Promise<void> | void'
+      }
+    ]
+  },
+  {
+    type: 'service',
+    name: 'NgxPuzzleExternalService',
+    description: 'External service exposing initialization and preview capabilities',
+    properties: [
+      {
+        name: 'getAllConfigs()',
+        description: 'Get all currently registered component configs.',
+        type: '() => ComponentConfig[]'
+      },
+      {
+        name: 'initializeComponent(configs)',
+        description: 'Initialize components from given configs. Accepts single or array. When type===\'canvas\', updates canvas config and selects it.',
+        type: '(configs: ComponentConfig | ComponentConfig[]) => void'
+      },
+      {
+        name: 'generatePreviewId(ttl?)',
+        description: 'Persist current configs to session storage and return a generated preview ID; optional TTL in ms.',
+        type: '(ttl?: number) => Promise<string>'
+      },
+      {
+        name: 'getConfigsByPreviewId(previewId)',
+        description: 'Fetch configs from session storage by preview ID.',
+        type: '(previewId: string) => Promise<ComponentConfig[] | null>'
+      },
+      {
+        name: 'resetAllComponents()',
+        description: 'Clear registry, injector and mediator states to a clean environment.',
+        type: '() => void'
+      }
+    ]
+  },
+  {
+    type: 'service',
+    name: 'NgxPuzzleDataBindingService',
+    description: 'Data binding gateway service: request/respond to bindings and notify control changes',
+    properties: [
+      {
+        name: 'bindingRequest$',
+        description: 'Stream of data-binding requests (Subject as Observable).',
+        type: 'Observable<NgxPuzzleDataBindingRequest>'
+      },
+      {
+        name: 'bindingResponse$',
+        description: 'Stream of data-binding responses (Subject as Observable).',
+        type: 'Observable<NgxPuzzleDataBindingResponse>'
+      },
+      {
+        name: 'controlChange$',
+        description: 'Stream that notifies external listeners when internal controls change.',
+        type: 'Observable<NgxPuzzleControlChangeNotification>'
+      },
+      {
+        name: 'activeRequest$',
+        description: 'The currently active binding request (BehaviorSubject as Observable).',
+        type: 'Observable<NgxPuzzleDataBindingRequest | null>'
+      },
+      {
+        name: 'bindingDelete$',
+        description: 'Notification stream for deleting a binding (componentId and seriesIndex).',
+        type: 'Observable<{ componentId: string; seriesIndex: number }>'
+      },
+      {
+        name: 'requestBinding(request)',
+        description: 'Emit a binding request and set it as the active request.',
+        type: '(request: NgxPuzzleDataBindingRequest) => void'
+      },
+      {
+        name: 'responseBinding(response)',
+        description: 'Complete a binding response, update mediator data request and emit response.',
+        type: '(response: NgxPuzzleDataBindingResponse) => void'
+      },
+      {
+        name: 'notifyControlChange(componentId, controlId, controlFilters)',
+        description: 'Notify external listeners of a control change.',
+        type: '(componentId: string, controlId: string, controlFilters: any) => void'
+      },
+      {
+        name: 'getDataStreamHash(dataStream)',
+        description: 'Get an identifier for a data stream (reference-based).',
+        type: '(dataStream: Observable<any>) => string'
+      },
+      {
+        name: 'removeSeriesBinding(componentId, seriesIndex)',
+        description: 'Remove API source at series index and emit delete/update events.',
+        type: '(componentId: string, seriesIndex: number) => void'
+      },
+      {
+        name: 'insertSeriesBinding(componentId, seriesIndex)',
+        description: 'Insert a placeholder API source at given index (requires later external config).',
+        type: '(componentId: string, seriesIndex: number) => void'
+      },
+      {
+        name: 'getComponentDataRequest(componentId)',
+        description: 'Get component data request config.',
+        type: '(componentId: string) => DataRequestConfig | undefined'
+      },
+      {
+        name: 'removeComponentDataRequest(componentId)',
+        description: 'Remove all data request configs for a component.',
+        type: '(componentId: string) => void'
+      },
+      {
+        name: 'getActiveRequest()',
+        description: 'Get current active binding request.',
+        type: '() => NgxPuzzleDataBindingRequest | null'
+      }
+    ]
+  }
 ];

--- a/example/src/app/configuration/parameters/api/zh-cn.js
+++ b/example/src/app/configuration/parameters/api/zh-cn.js
@@ -1,379 +1,194 @@
 module.exports = [
-    {
-        type: 'component',
-        name: 'ngx-gantt',
-        description: '',
-        properties: [
-            {
-                name: 'items',
-                description: `设置数据项，如果单独设置items则会以列表形式展示，如果需要分组展示，则需要设置属性groupId对应分组数据`,
-                type: 'GanttItem[]'
-            },
-            {
-                name: 'groups',
-                description: `设置分组数据`,
-                type: 'GanttGroup[]'
-            },
-            {
-                name: 'baselineItems',
-                description: `设置基线对比数据`,
-                type: 'GanttBaselineItem[]'
-            },
-            {
-                name: 'viewType',
-                description: `设置视图类型`,
-                type: `day | month | quarter`,
-                default: 'month'
-            },
-            {
-                name: 'start',
-                description: `设置甘特图开始时间，格式为10位时间戳`,
-                type: 'number'
-            },
-            {
-                name: 'end',
-                description: `设置甘特图结束时间，格式为10位时间戳`,
-                type: 'number'
-            },
-            {
-                name: 'draggable',
-                description: `设置是否可拖拽`,
-                type: 'boolean',
-                default: 'false'
-            },
-            {
-                name: 'virtualScrollEnabled',
-                description: `设置是否使用虚拟滚动功能`,
-                type: 'boolean',
-                default: 'true'
-            },
-            {
-                name: 'linkable',
-                description: `设置是否可连接关联关系`,
-                type: 'boolean',
-                default: 'false'
-            },
-
-            {
-                name: 'loading',
-                description: `是否展示加载器`,
-                type: 'boolean',
-                default: 'false'
-            },
-
-            {
-                name: 'loadingDelay',
-                description: '设置在多少`毫秒`内,忽略加载器展示',
-                type: 'number',
-                default: '0'
-            },
-
-            {
-                name: 'maxLevel',
-                description: `设置最大展示层级`,
-                type: 'number',
-                default: 2
-            },
-
-            {
-                name: 'async',
-                description: `设置是否开始异步`,
-                type: 'boolean',
-                default: 'false'
-            },
-            {
-                name: 'childrenResolve',
-                description: `设置异步数据源返回函数，返回值为 Observable 数据流`,
-                type: 'Function'
-            },
-
-            {
-                name: 'styles',
-                description: `配置内置的样式选项`,
-                type: 'GanttStyles'
-            },
-            {
-                name: 'viewOptions',
-                description: `配置视图选项`,
-                type: 'GanttViewOptions'
-            },
-            {
-                name: 'disabledLoadOnScroll',
-                description: `设置是否禁用滚动加载`,
-                type: 'boolean',
-                default: false
-            },
-            {
-                name: 'selectable',
-                description: `设置是否启动选择整行`,
-                type: 'boolean',
-                default: 'false'
-            },
-            {
-                name: 'multiple',
-                description: `设置选择整行是否为多选模式`,
-                type: 'boolean',
-                default: 'false'
-            },
-            {
-                name: 'showToolbar',
-                description: `设置是否展示工具栏`,
-                type: 'boolean',
-                default: 'false'
-            },
-            {
-                name: 'toolbarOptions',
-                description: `工具栏配置项`,
-                type: 'GanttToolbarOptions',
-                default: `{
-                    viewTypes: [GanttViewType.day, GanttViewType.month, GanttViewType.year]
-                }`
-            },
-            {
-                name: 'loadOnScroll',
-                description: `滚动加载事件`,
-                type: 'EventEmitter<GanttLoadOnScrollEvent>'
-            },
-            {
-                name: 'dragStarted',
-                description: `拖拽开始后事件`,
-                type: 'EventEmitter<GanttDragEvent>'
-            },
-            {
-                name: 'dragEnded',
-                description: `拖拽结束后事件`,
-                type: 'EventEmitter<GanttDragEvent>'
-            },
-            {
-                name: 'linkDragStarted',
-                description: `关联关系拖拽开始后事件`,
-                type: 'EventEmitter<GanttLinkDragEvent>'
-            },
-            {
-                name: 'linkDragEnded',
-                description: `关联关系拖拽结束后事件`,
-                type: 'EventEmitter<GanttLinkDragEvent>'
-            },
-            {
-                name: 'barClick',
-                description: `右侧时间条点击事件`,
-                type: 'EventEmitter<GanttBarClickEvent>'
-            },
-            {
-                name: 'lineClick',
-                description: `关联关系线点击时间`,
-                type: 'EventEmitter<GanttLinkDragEvent>'
-            },
-            {
-                name: 'selectedChange',
-                description: `选择数据项事件`,
-                type: 'EventEmitter<GanttSelectedEvent>'
-            },
-            {
-                name: 'virtualScrolledIndexChange',
-                description: `虚拟滚动视口中可见的第一个元素的索引发生变化事件`,
-                type: 'EventEmitter<GanttVirtualScrolledIndexChangeEvent>'
-            },
-            {
-                name: '#group',
-                description: `设置分组显示模板`,
-                type: 'TemplateRef<any>'
-            },
-            {
-                name: '#bar',
-                description: `设置时间条显示模板`,
-                type: 'TemplateRef<any>'
-            },
-            {
-                name: '#groupHeader',
-                description: `设置分组头部显示模板`,
-                type: 'TemplateRef<any>'
-            },
-            {
-                name: '#toolbar',
-                description: `工具栏自定义模版`,
-                type: 'TemplateRef<any>'
-            },
-            {
-                name: '#tableFooter',
-                description: `设置底部模板`,
-                type: 'TemplateRef<any>'
-            }
-        ]
-    },
-    {
-        type: 'component',
-        name: 'ngx-gantt-table',
-        description: '甘特图左侧表格',
-        properties: [
-            {
-                name: 'draggable',
-                description: `设置表格数据项是否支持上下拖动排序`,
-                default: false,
-                type: 'boolean'
-            },
-            {
-                name: 'dropEnterPredicate',
-                description: `该函数用于判断是否允许某个数据项拖到其他项`,
-                type: '(context: GanttTableDragEnterPredicateContext<T>) => boolean'
-            },
-            {
-                name: 'dragDropped',
-                description: `当把一个数据项拖动到另一个数据项时就会触发`,
-                type: 'EventEmitter<GanttTableDragDroppedEvent>'
-            },
-            {
-                name: 'dragStarted',
-                description: `拖拽开始后事件`,
-                type: 'EventEmitter<GanttTableDragStartedEvent>'
-            },
-            {
-                name: 'dragEnded',
-                description: `拖拽结束后事件`,
-                type: 'EventEmitter<GanttTableDragEndedEvent>'
-            },
-            {
-                name: 'columnChanges',
-                description: `列宽变化事件集`,
-                type: 'EventEmitter<GanttTableEvent>'
-            },
-            {
-                name: 'itemClick',
-                description: `选择整行数据项事件`,
-                type: 'EventEmitter<GanttSelectedEvent>'
-            },
-            {
-                name: '#rowBeforeSlot',
-                description: `设置表格中每行的前置自定义渲染模板`,
-                type: 'TemplateRef<any>'
-            },
-            {
-                name: '#rowAfterSlot',
-                description: `设置表格中每行的后置自定义渲染模板`,
-                type: 'TemplateRef<any>'
-            },
-            {
-                name: '#tableEmpty',
-                description: `设置空表格模板`,
-                type: 'TemplateRef<any>'
-            },
-            {
-                name: '#tableFooter',
-                description: `设置表格底部模板`,
-                type: 'TemplateRef<any>'
-            }
-        ]
-    },
-    {
-        type: 'component',
-        name: 'ngx-gantt-column',
-        description: '甘特图左侧列',
-        properties: [
-            {
-                name: 'name',
-                description: `设置列名称`,
-                type: 'string'
-            },
-            {
-                name: 'width',
-                description: `设置列宽`,
-                type: 'string ｜ number'
-            },
-            {
-                name: '#header',
-                description: `设置每列头部模板`,
-                type: 'TemplateRef<any>'
-            },
-            {
-                name: '#cell',
-                description: `设置每列内容模板`,
-                type: 'TemplateRef<any>'
-            }
-        ]
-    },
-    {
-        type: 'component',
-        name: 'ngx-gantt-bar',
-        description: '数据项条形图展示组件',
-        properties: [
-            {
-                name: 'template',
-                description: `设置时间条显示模板`,
-                type: 'TemplateRef<any>'
-            },
-            {
-                name: 'item',
-                description: `设置时间条显示数据`,
-                type: 'GanttItemInternal'
-            },
-            {
-                name: 'barClick',
-                description: `数据项条形图点击事件`,
-                type: 'EventEmitter<GanttBarClickEvent>'
-            }
-        ]
-    },
-    {
-        type: 'component',
-        name: 'ngx-gantt-range',
-        description: '数据项区间展示组件',
-        properties: [
-            {
-                name: 'template',
-                description: `设置区间展示模板`,
-                type: 'TemplateRef<any>'
-            },
-            {
-                name: 'item',
-                description: `设置区间展示数据`,
-                type: 'GanttItemInternal'
-            }
-        ]
-    },
-    {
-        type: 'component',
-        name: 'ngx-gantt-toolbar',
-        description: '工具栏组件',
-        properties: [
-            {
-                name: 'template',
-                description: `自定义工具栏模板`,
-                type: 'TemplateRef<any>'
-            }
-        ]
-    },
-    {
-        type: 'component',
-        name: 'ngx-gantt-baseline',
-        description: '基线展示组件',
-        properties: [
-            {
-                name: 'baselineItem',
-                description: `设置基线展示数据`,
-                type: 'GanttBaselineItemInternal'
-            }
-        ]
-    },
-    {
-        type: 'component',
-        name: 'ngx-gantt-root',
-        description: '甘特图根组件',
-        properties: [
-            {
-                name: 'sideWidth',
-                description: `设置甘特图左侧内容宽度`,
-                type: 'number'
-            },
-            {
-                name: 'sideTemplate',
-                description: `设置甘特图左侧内容模板`,
-                type: 'TemplateRef<any>'
-            },
-            {
-                name: 'mainTemplate',
-                description: `设置甘特图右侧主要内容模板`,
-                type: 'TemplateRef<any>'
-            }
-        ]
-    }
+  {
+    type: 'component',
+    name: 'ngx-puzzle-editor',
+    description: '可视化拼图编辑器组件（编辑模式容器）',
+    properties: [
+      {
+        name: 'selector',
+        description: '选择器别名',
+        type: "`ngx-puzzle-editor` | 'puzzle-editor'"
+      },
+      {
+        name: 'inputs',
+        description: '当前版本无输入参数。编辑器内部使用信号管理折叠状态(leftCollapsed/rightCollapsed)。',
+        type: '—'
+      },
+      {
+        name: 'outputs',
+        description: '当前版本无输出事件。',
+        type: '—'
+      }
+    ]
+  },
+  {
+    type: 'component',
+    name: 'ngx-puzzle-preview',
+    description: '拼图预览组件（渲染画布与组件预览）',
+    properties: [
+      {
+        name: 'selector',
+        description: '选择器别名',
+        type: "'ngx-puzzle-preview' | 'puzzle-preview'"
+      },
+      {
+        name: 'enableZoom',
+        description: '是否启用缩放（支持双向绑定）。true：按窗口宽度等比缩放；false：原始尺寸显示。',
+        type: 'boolean',
+        default: true
+      },
+      {
+        name: 'enableZoomBtn',
+        description: '是否启用缩放按钮；false 时按钮不可用。',
+        type: 'boolean',
+        default: false
+      },
+      {
+        name: 'enableFullscreenBtn',
+        description: '是否启用全屏按钮。',
+        type: 'boolean',
+        default: true
+      },
+      {
+        name: 'previewId',
+        description: '预览ID（仅在 previewMode 为 edit 时使用），用于从会话存储中加载临时配置。',
+        type: 'string | undefined'
+      },
+      {
+        name: 'previewMode',
+        description: '预览模式：normal（仅使用传入的 passedConfig）；edit（结合 previewId 从会话中加载临时数据）。',
+        type: "'normal' | 'edit'",
+        default: 'normal'
+      },
+      {
+        name: 'passedConfig',
+        description: '正常预览模式下传入的组件配置列表。',
+        type: 'ComponentConfig[] | undefined'
+      },
+      {
+        name: 'methods.toggleZoomMode()',
+        description: '切换缩放模式；关闭缩放时恢复比例为 1。',
+        type: '() => void'
+      },
+      {
+        name: 'methods.isFullscreen()',
+        description: '是否处于全屏状态。',
+        type: '() => boolean'
+      },
+      {
+        name: 'methods.toggleFullscreen()',
+        description: '在全屏与非全屏之间切换。',
+        type: '() => Promise<void> | void'
+      }
+    ]
+  },
+  {
+    type: 'service',
+    name: 'NgxPuzzleExternalService',
+    description: '对外提供组件初始化与预览能力的服务',
+    properties: [
+      {
+        name: 'getAllConfigs()',
+        description: '获取当前已注册的所有组件配置。',
+        type: '() => ComponentConfig[]'
+      },
+      {
+        name: 'initializeComponent(configs)',
+        description: '根据传入配置初始化组件。支持传入单个或数组；包含 type===\'canvas\' 时将更新画布配置并选中画布。',
+        type: '(configs: ComponentConfig | ComponentConfig[]) => void'
+      },
+      {
+        name: 'generatePreviewId(ttl?)',
+        description: '保存当前配置到会话存储并返回生成的预览ID；可选传入生存时间(毫秒)。',
+        type: '(ttl?: number) => Promise<string>'
+      },
+      {
+        name: 'getConfigsByPreviewId(previewId)',
+        description: '通过预览ID从会话存储获取配置。',
+        type: '(previewId: string) => Promise<ComponentConfig[] | null>'
+      },
+      {
+        name: 'resetAllComponents()',
+        description: '清空注册表、注入器与中介者状态，恢复到干净环境。',
+        type: '() => void'
+      }
+    ]
+  },
+  {
+    type: 'service',
+    name: 'NgxPuzzleDataBindingService',
+    description: '数据绑定对接服务：负责发起、响应绑定请求以及控件变更通知等',
+    properties: [
+      {
+        name: 'bindingRequest$',
+        description: '数据绑定请求流（Subject as Observable）。',
+        type: 'Observable<NgxPuzzleDataBindingRequest>'
+      },
+      {
+        name: 'bindingResponse$',
+        description: '数据绑定响应流（Subject as Observable）。',
+        type: 'Observable<NgxPuzzleDataBindingResponse>'
+      },
+      {
+        name: 'controlChange$',
+        description: '控件变化通知流（内部控件变化时对外通知）。',
+        type: 'Observable<NgxPuzzleControlChangeNotification>'
+      },
+      {
+        name: 'activeRequest$',
+        description: '当前激活绑定请求（BehaviorSubject as Observable）。',
+        type: 'Observable<NgxPuzzleDataBindingRequest | null>'
+      },
+      {
+        name: 'bindingDelete$',
+        description: '删除绑定的通知流（包含 componentId 与 seriesIndex）。',
+        type: 'Observable<{ componentId: string; seriesIndex: number }>'
+      },
+      {
+        name: 'requestBinding(request)',
+        description: '发起绑定请求并设置为当前激活请求。',
+        type: '(request: NgxPuzzleDataBindingRequest) => void'
+      },
+      {
+        name: 'responseBinding(response)',
+        description: '完成绑定响应，更新中介者数据请求并发布响应事件。',
+        type: '(response: NgxPuzzleDataBindingResponse) => void'
+      },
+      {
+        name: 'notifyControlChange(componentId, controlId, controlFilters)',
+        description: '对外通知控件变化。',
+        type: '(componentId: string, controlId: string, controlFilters: SafeAny) => void'
+      },
+      {
+        name: 'getDataStreamHash(dataStream)',
+        description: '获取数据流的标识（基于引用）。',
+        type: '(dataStream: Observable<any>) => string'
+      },
+      {
+        name: 'removeSeriesBinding(componentId, seriesIndex)',
+        description: '删除指定系列的 API 数据源并发布删除与更新事件。',
+        type: '(componentId: string, seriesIndex: number) => void'
+      },
+      {
+        name: 'insertSeriesBinding(componentId, seriesIndex)',
+        description: '在指定位置插入占位 API 源（需外部后续配置）。',
+        type: '(componentId: string, seriesIndex: number) => void'
+      },
+      {
+        name: 'getComponentDataRequest(componentId)',
+        description: '获取组件的数据请求配置。',
+        type: '(componentId: string) => DataRequestConfig | undefined'
+      },
+      {
+        name: 'removeComponentDataRequest(componentId)',
+        description: '删除组件的全部数据请求配置。',
+        type: '(componentId: string) => void'
+      },
+      {
+        name: 'getActiveRequest()',
+        description: '获取当前激活的绑定请求。',
+        type: '() => NgxPuzzleDataBindingRequest | null'
+      }
+    ]
+  }
 ];


### PR DESCRIPTION
… preview modules

- Removed legacy Gantt chart component definitions and configurations.
- Introduced `ngx-puzzle-editor` and `ngx-puzzle-preview` components for enhanced visual editing and preview capabilities.
- Added new services (`NgxPuzzleExternalService` and `NgxPuzzleDataBindingService`) to manage component initialization, data binding, and configuration handling.
- Updated EN/CH README files to reflect API and component changes.