### PR TITLE
fix(release): skip draft update when Unreleased is empty

### DIFF
--- a/.github/scripts/extract_unreleased.sh
+++ b/.github/scripts/extract_unreleased.sh
@@ -20,7 +20,10 @@ UNRELEASED_CONTENT="$(
 
 if [[ -z "${UNRELEASED_CONTENT}" ]]; then
   echo "No content found under ## [Unreleased] in ${CHANGELOG_FILE}."
-  exit 1
+  if [[ -n "${OUTPUT_FILE}" ]]; then
+    : > "${OUTPUT_FILE}"
+  fi
+  exit 2
 fi
 
 if [[ -n "${OUTPUT_FILE}" ]]; then

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -38,18 +38,40 @@ jobs:
             PRERELEASE="false"
           fi
 
+          set +e
           bash .github/scripts/extract_unreleased.sh CHANGELOG.md .release_notes.txt
+          EXTRACT_EXIT_CODE="$?"
+          set -e
+
+          if [[ "${EXTRACT_EXIT_CODE}" -eq 2 ]]; then
+            echo "Unreleased section is empty, skipping draft upsert."
+            {
+              echo "version=${VERSION}"
+              echo "tag=${TAG}"
+              echo "prerelease=${PRERELEASE}"
+              echo "skipped=true"
+              echo "body="
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "${EXTRACT_EXIT_CODE}" -ne 0 ]]; then
+            echo "Failed to extract Unreleased notes."
+            exit "${EXTRACT_EXIT_CODE}"
+          fi
 
           {
             echo "version=${VERSION}"
             echo "tag=${TAG}"
             echo "prerelease=${PRERELEASE}"
+            echo "skipped=false"
             echo "body<<EOF"
             cat .release_notes.txt
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
       - name: Upsert GitHub release draft
+        if: ${{ steps.meta.outputs.skipped != 'true' }}
         uses: actions/github-script@v7
         env:
           RELEASE_TAG: ${{ steps.meta.outputs.tag }}


### PR DESCRIPTION
## Summary\n- adjust extract script to return a dedicated skip exit code when  is empty\n- update release-draft workflow to treat skip as success and avoid red main\n- keep changelog gate behavior unchanged for code-impacting PRs\n\n## Validation\n- bash .github/scripts/extract_unreleased.sh /tmp/puzzle-empty-changelog.md /tmp/puzzle-empty-notes.txt (exit 2, empty output)\n\n## Risk / Rollback\n- low risk: only draft workflow decision logic changed\n- rollback by reverting this PR