### PR TITLE
chore(ci): harden changelog gate

### DIFF
--- a/.github/scripts/check_unreleased_update.sh
+++ b/.github/scripts/check_unreleased_update.sh
@@ -36,6 +36,8 @@ while IFS= read -r file; do
   [[ -z "${file}" ]] && continue
   if [[ "${file}" =~ ^projects/ ]] \
     || [[ "${file}" =~ ^scripts/ ]] \
+    || [[ "${file}" =~ ^\.github/workflows/ ]] \
+    || [[ "${file}" =~ ^\.github/scripts/ ]] \
     || [[ "${file}" == "package.json" ]] \
     || [[ "${file}" == "package-lock.json" ]] \
     || [[ "${file}" == "angular.json" ]] \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Validate Unreleased update for code changes
+      - name: Validate Unreleased update for code-impacting changes
         run: |
           bash .github/scripts/check_unreleased_update.sh \
             "${{ github.event.pull_request.base.sha }}" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- chore(ci): treat GitHub workflow and CI script changes as code-impacting PRs for the changelog gate.
+
 ## 21.0.0 (2026-04-14)
 
 ### ✨ Added

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -3,6 +3,8 @@
 
 ## [Unreleased]
 
+- chore(ci): 将 GitHub workflow 与 CI 脚本变更纳入 changelog 门禁的代码影响范围。
+
 ## 21.0.0 (2026-04-14)
 
 ### ✨ 新增
@@ -25,5 +27,4 @@
 * 修复 control 组件样式与属性问题。([2985509](https://github.com/zhongmiao-org/ngx-puzzle/commit/2985509))
 * 修复 form-renderer 样式问题。([c66d6dc](https://github.com/zhongmiao-org/ngx-puzzle/commit/c66d6dc))
 * 修复 `build:docs` 的 CI warning。([f94ed53](https://github.com/zhongmiao-org/ngx-puzzle/commit/f94ed53))
-
 


### PR DESCRIPTION
## Summary

- Treat `.github/workflows/**` and `.github/scripts/**` changes as code-impacting for the PR changelog gate.
- Keep the PR -> main `Changelog gate` job in CI and clarify its step label.
- Add English and Chinese Unreleased notes for this governance change.

## Validation

- `bash -n .github/scripts/check_unreleased_update.sh`
- `bash .github/scripts/check_unreleased_update.sh origin/main HEAD`
- `git diff --check HEAD~1 HEAD`

Note: full `npm run format:check` currently fails on pre-existing repository formatting/generated HTML issues unrelated to this PR.